### PR TITLE
Made a createRoute function, moved currentStack to the StackRouter, m…

### DIFF
--- a/Beeline.xcodeproj/project.pbxproj
+++ b/Beeline.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		73ED167A1C3E2E65003B3827 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ED16791C3E2E65003B3827 /* WelcomeViewController.swift */; };
 		73ED16801C3E2F14003B3827 /* FormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ED167F1C3E2F14003B3827 /* FormViewController.swift */; };
 		73ED16881C3E31EC003B3827 /* ColorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ED16871C3E31EC003B3827 /* ColorViewModel.swift */; };
+		BCD9EDA31C3E9EC30096EEE7 /* RouterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD9EDA21C3E9EC30096EEE7 /* RouterViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +86,7 @@
 		73ED16791C3E2E65003B3827 /* WelcomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		73ED167F1C3E2F14003B3827 /* FormViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormViewController.swift; sourceTree = "<group>"; };
 		73ED16871C3E31EC003B3827 /* ColorViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorViewModel.swift; sourceTree = "<group>"; };
+		BCD9EDA21C3E9EC30096EEE7 /* RouterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +175,7 @@
 				7349E7571C3DD759004A507B /* StackRouter.swift */,
 				7349E75A1C3DD759004A507B /* URLPath.swift */,
 				7349E75B1C3DD759004A507B /* ZippedStack.swift */,
+				BCD9EDA21C3E9EC30096EEE7 /* RouterViewController.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCD9EDA31C3E9EC30096EEE7 /* RouterViewController.swift in Sources */,
 				7349E76A1C3DD759004A507B /* SegmentViewCreator.swift in Sources */,
 				7349E76E1C3DD759004A507B /* URLPath.swift in Sources */,
 				7349E7691C3DD759004A507B /* SegmentViewController.swift in Sources */,

--- a/Demo/AppCoordinator.swift
+++ b/Demo/AppCoordinator.swift
@@ -12,10 +12,10 @@ import Beeline
 func AppCoordinator() -> UIViewController {
 
     var router: StackRouter!
-    let navigationController = StackViewController()
+    let navigationController = UIStackViewController();
     let store = AppStore(setPath: { router.setPath($0) })
 
-    router = StackRouter([
+    router = createRouter([
         Route("welcome", WelcomePresenter(store), [
             Route("login", LoginPresenter()),
             Route("register", RegistrationPresenter()),

--- a/Demo/Presenters/LoginPresenter.swift
+++ b/Demo/Presenters/LoginPresenter.swift
@@ -11,7 +11,7 @@ import UIKit
 
 struct LoginPresenter: SegmentViewCreator {
 
-    func create(path: Path) -> UIViewController {
-        return FormViewController(ColorViewModel(UIColor.greenColor()))
+    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController {
+        return FormViewController(ColorViewModel(UIColor.greenColor()), path: path, dismiss: dismiss)
     }
 }

--- a/Demo/Presenters/RegistrationPresenter.swift
+++ b/Demo/Presenters/RegistrationPresenter.swift
@@ -11,7 +11,7 @@ import UIKit
 
 struct RegistrationPresenter: SegmentViewCreator {
 
-    func create(path: Path) -> UIViewController {
-        return FormViewController(ColorViewModel(UIColor.blueColor()))
+    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController {
+        return FormViewController(ColorViewModel(UIColor.blueColor()), path: path, dismiss: dismiss)
     }
 }

--- a/Demo/Presenters/WelcomePresenter.swift
+++ b/Demo/Presenters/WelcomePresenter.swift
@@ -17,8 +17,8 @@ struct WelcomePresenter: SegmentViewCreator {
         self.store = store
     }
 
-    func create(path: Path) -> UIViewController {
-        return WelcomeViewController(viewModel: WelcomeViewModel(store: store))
+    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController {
+        return WelcomeViewController(WelcomeViewModel(store: store), path: path, dismiss: dismiss)
     }
 }
 

--- a/Demo/ViewControllers/FormViewController.swift
+++ b/Demo/ViewControllers/FormViewController.swift
@@ -7,19 +7,25 @@
 //
 
 import UIKit
+import Beeline
 
-class FormViewController: UIViewController {
+class FormViewController: UIRouterViewController {
 
     let viewModel: ProvidesColor
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    init(_ viewModel: ProvidesColor) {
+    
+    init(_ viewModel: ProvidesColor, path: Path, dismiss: (Path) -> ()) {
         self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        super.init(path: path, dismiss: dismiss);
     }
+
+    internal required init(path: Path, dismiss: (Path) -> Void) {
+        fatalError("init(path:dismiss:) has not been implemented")
+    }
+
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Demo/ViewControllers/WelcomeViewController.swift
+++ b/Demo/ViewControllers/WelcomeViewController.swift
@@ -7,8 +7,9 @@
 //
 
 import UIKit
+import Beeline
 
-class WelcomeViewController: UIViewController {
+class WelcomeViewController: UIRouterViewController {
 
     let viewModel: WelcomeViewModel
 
@@ -17,10 +18,14 @@ class WelcomeViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    init(viewModel: WelcomeViewModel) {
+    
+    init(_ viewModel: WelcomeViewModel, path: Path, dismiss: (Path) -> ()) {
         self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        super.init(path: path, dismiss: dismiss);
+    }
+    
+    internal required init(path: Path, dismiss: (Path) -> Void) {
+        fatalError("init(path:dismiss:) has not been implemented")
     }
 
     override func loadView() {
@@ -37,6 +42,7 @@ class WelcomeViewController: UIViewController {
     }
 
     func didClickLogin(button: UIButton) {
+        print(navigationController?.viewControllers.count);
         viewModel.navigateToLogin()
     }
 

--- a/Sources/Core/RouterViewController.swift
+++ b/Sources/Core/RouterViewController.swift
@@ -1,0 +1,50 @@
+//
+//  RouterController.swift
+//  Beeline
+//
+//  Created by Aleksander Herforth Rendtslev on 07/01/16.
+//  Copyright © 2016 Featherweight Labs. All rights reserved.
+//
+
+import Foundation
+
+/**
+
+ Standard RouterViewController Protocol
+ This must be implemented by both the iOS and Appkit implementation
+ */
+public protocol RouterViewController {
+    var path: Path {get}
+    var dismiss: (Path) -> Void  {get}
+    init(path: Path, dismiss: (Path) -> Void);
+}
+
+/**
+ UIViewController implementation of the RouterViewController.
+*/
+public class UIRouterViewController : UIViewController, RouterViewController {
+    
+    public var path:Path;
+    public var dismiss: (Path) -> Void;
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public required init(path: Path, dismiss: (Path) -> Void) {
+        self.path = path;
+        self.dismiss = dismiss;
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    public override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        if (self.isMovingFromParentViewController()){
+            // Your code...
+            print("I am going back");
+            dismiss(path);
+            
+        }
+    }
+}

--- a/Sources/Core/Segment.swift
+++ b/Sources/Core/Segment.swift
@@ -28,8 +28,8 @@ public struct Segment: Equatable {
         self.segmentViewCreator = segmentViewCreator
     }
 
-    func create() -> UIViewController {
-        return segmentViewCreator.create(path)
+    func create(dismiss: (Path) -> ()) -> RouterViewController {
+        return segmentViewCreator.create(path, dismiss: dismiss);
     }
 }
 

--- a/Sources/Core/SegmentViewController.swift
+++ b/Sources/Core/SegmentViewController.swift
@@ -6,44 +6,106 @@
 //  Copyright © 2016 Featherweight Labs. All rights reserved.
 //
 
-public class StackViewController: UINavigationController {
 
-    public enum TransitionAction {
-        case Pop(Segment)
-        case Push(Segment)
-        case Change(Segment)
-    }
+public enum TransitionAction {
+    case Pop(Segment)
+    case Push(Segment)
+    case Change(Segment)
+}
 
-    public var currentStack: [Segment] = []
+/**
+ StackViewController. 
+ This is basic protocol for the basic stack controller.
+*/
+public protocol StackViewController {
+    
+    var dismissViewController : (Path) -> () {get set}
+    func setStack(currentStack: [Segment], newStack: [Segment]) -> [Segment]
+    func popFromStack(currentStack: [Segment]) -> [Segment];
+    func transitionActions(stack: ZippedStack<Segment>) -> [TransitionAction]
+    func performActions(actionStack: [TransitionAction]) throws
+}
 
-    public func setStack(newStack: [Segment]) {
 
-        let transitionStack = ZippedStack(currentStack, newStack)
-        let stackActions = transitionActions(transitionStack)
-        performActions(stackActions)
-        currentStack = newStack
-    }
-
+/**
+ Contains default implementations of basic navigation related methods
+*/
+// MARK: - StackViewController
+extension StackViewController {
     public func transitionActions(stack: ZippedStack<Segment>) -> [TransitionAction] {
-
+        
         let fromActions: [TransitionAction] = stack.from.reverse().map { .Pop($0) }
         let toActions: [TransitionAction] = stack.to.map { .Push($0) }
         return fromActions + toActions
     }
+    public func setStack(currentStack: [Segment], newStack: [Segment]) -> [Segment]{
+        let transitionStack = ZippedStack(currentStack, newStack)
+        let stackActions = transitionActions(transitionStack)
+        
+        do {
+            try performActions(stackActions)
+        } catch {
+            
+        }
+        return newStack
+    }
+    
+    /**
+     Used for going back in the stack. As an alternative to the native go back function
+    */
+    public func popFromStack(currentStack: [Segment]) -> [Segment] {
+        var newStack = currentStack;
+        newStack.popLast();
+        
+        let transitionStack = ZippedStack(currentStack, newStack);
+        let stackActions = transitionActions(transitionStack)
 
-    public func performActions(actionStack: [TransitionAction]) {
+        do {
+            try performActions(stackActions)
+        } catch {
+            
+        }
+        return newStack
+    }
+}
+
+
+/**
+ UIKit implementation of the StackViewController
+*/
+public class UIStackViewController: UINavigationController, StackViewController {
+    public var dismissViewController: (Path) -> () = { path in};
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public init(){
+        super.init(nibName: nil, bundle: nil);
+    }
+  
+    public func performActions(actionStack: [TransitionAction]) throws {
         for action in actionStack {
             switch action {
-
+                
             case .Push(let segment):
-                pushViewController(segment.create(), animated: true)
-
+                guard let uiViewController = segment.create(dismissViewController) as? UIViewController else {
+                    throw RouterError.InvalidViewControllerType
+                }
+                pushViewController(uiViewController, animated: true)
+                
             case .Pop:
                 popViewControllerAnimated(true)
-
+                
             case .Change:
                 fatalError("No change event yet")
             }
         }
     }
 }
+
+
+enum RouterError: ErrorType {
+    case InvalidViewControllerType
+}
+

--- a/Sources/Core/SegmentViewCreator.swift
+++ b/Sources/Core/SegmentViewCreator.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+
 public protocol SegmentViewCreator {
-    func create(path: Path) -> UIViewController
+    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController
 }


### PR DESCRIPTION
Made naive implementation of af dismissFunction that updates the stack, create RouterViewProtocol instead of relying directly on UIViewController

---

This was forked 17 commits ago, so much of it might be redundant. But I wanted to setup the pull request so you could look at and discuss some of the solutions.

The main points are:

RouterViewProtocol - which is a protocol that abstracts away uiviewcontrollers from the inner workings of the framework. You might have already solved this (I did the code offline on the plane)

dismissFunction - showing how the back function can be made to update the stack. The way it's implemented is way too imperative - and I still question whether the functionality should be used. But it shows how it can be done at least :)
