### PR TITLE
[Refactor] call dismiss inside didMoveToParentViewController with DismissEmitter protocol

### DIFF
--- a/Beeline.xcodeproj/project.pbxproj
+++ b/Beeline.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		7349E7BA1C3DDAD2004A507B /* WelcomePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7349E7B61C3DDAD2004A507B /* WelcomePresenter.swift */; };
 		73612BC21C3E129100FD841A /* LoginPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73612BC01C3E126F00FD841A /* LoginPresenter.swift */; };
 		73612BC51C3E13BD00FD841A /* RegistrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73612BC31C3E13B100FD841A /* RegistrationPresenter.swift */; };
+		73909B831C42012000F027C7 /* RouterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73909B821C42012000F027C7 /* RouterError.swift */; };
 		73ED16761C3E2DF9003B3827 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ED16751C3E2DF9003B3827 /* WelcomeView.swift */; };
 		73ED16781C3E2E44003B3827 /* WelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ED16771C3E2E44003B3827 /* WelcomeViewModel.swift */; };
 		73ED167A1C3E2E65003B3827 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ED16791C3E2E65003B3827 /* WelcomeViewController.swift */; };
@@ -84,6 +85,7 @@
 		7349E7B61C3DDAD2004A507B /* WelcomePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomePresenter.swift; sourceTree = "<group>"; };
 		73612BC01C3E126F00FD841A /* LoginPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginPresenter.swift; sourceTree = "<group>"; };
 		73612BC31C3E13B100FD841A /* RegistrationPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationPresenter.swift; sourceTree = "<group>"; };
+		73909B821C42012000F027C7 /* RouterError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterError.swift; sourceTree = "<group>"; };
 		73ED16751C3E2DF9003B3827 /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		73ED16771C3E2E44003B3827 /* WelcomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViewModel.swift; sourceTree = "<group>"; };
 		73ED16791C3E2E65003B3827 /* WelcomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				7349E7501C3DD759004A507B /* Regex.swift */,
 				7349E7511C3DD759004A507B /* Route.swift */,
 				73F3FED91C3E771B00048DE2 /* Router.swift */,
+				73909B821C42012000F027C7 /* RouterError.swift */,
 				73F280051C41F6630043B1BB /* RouterViewController.swift */,
 				7349E7541C3DD759004A507B /* Segment.swift */,
 				7349E7561C3DD759004A507B /* SegmentViewCreator.swift */,
@@ -469,6 +472,7 @@
 				7349E7631C3DD759004A507B /* Path.swift in Sources */,
 				73F3FEDC1C3E835000048DE2 /* JunctionRouter.swift in Sources */,
 				7349E7681C3DD759004A507B /* Segment.swift in Sources */,
+				73909B831C42012000F027C7 /* RouterError.swift in Sources */,
 				7349E7651C3DD759004A507B /* Route.swift in Sources */,
 				73F280061C41F6630043B1BB /* RouterViewController.swift in Sources */,
 				7349E76F1C3DD759004A507B /* ZippedStack.swift in Sources */,

--- a/Beeline.xcodeproj/project.pbxproj
+++ b/Beeline.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		73F3FEDA1C3E771B00048DE2 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F3FED91C3E771B00048DE2 /* Router.swift */; };
 		73F3FEDC1C3E835000048DE2 /* JunctionRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F3FEDB1C3E835000048DE2 /* JunctionRouter.swift */; };
 		73F3FEDE1C3E93DF00048DE2 /* JunctionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F3FEDD1C3E93DF00048DE2 /* JunctionViewController.swift */; };
+		73FA154D1C42A1E000AA691E /* CallbackCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FA154C1C42A1E000AA691E /* CallbackCollection.swift */; };
+		73FA154F1C42A1F900AA691E /* DismissEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FA154E1C42A1F900AA691E /* DismissEmitter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +97,8 @@
 		73F3FED91C3E771B00048DE2 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		73F3FEDB1C3E835000048DE2 /* JunctionRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JunctionRouter.swift; sourceTree = "<group>"; };
 		73F3FEDD1C3E93DF00048DE2 /* JunctionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JunctionViewController.swift; sourceTree = "<group>"; };
+		73FA154C1C42A1E000AA691E /* CallbackCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallbackCollection.swift; sourceTree = "<group>"; };
+		73FA154E1C42A1F900AA691E /* DismissEmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DismissEmitter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +178,8 @@
 		7349E74C1C3DD759004A507B /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				73FA154C1C42A1E000AA691E /* CallbackCollection.swift */,
+				73FA154E1C42A1F900AA691E /* DismissEmitter.swift */,
 				73F3FEDB1C3E835000048DE2 /* JunctionRouter.swift */,
 				73F3FEDD1C3E93DF00048DE2 /* JunctionViewController.swift */,
 				7349E74F1C3DD759004A507B /* Path.swift */,
@@ -464,6 +470,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73F3FEDE1C3E93DF00048DE2 /* JunctionViewController.swift in Sources */,
+				73FA154F1C42A1F900AA691E /* DismissEmitter.swift in Sources */,
 				7349E76A1C3DD759004A507B /* SegmentViewCreator.swift in Sources */,
 				7349E76E1C3DD759004A507B /* URLPath.swift in Sources */,
 				73F3FEDA1C3E771B00048DE2 /* Router.swift in Sources */,
@@ -474,6 +481,7 @@
 				7349E7681C3DD759004A507B /* Segment.swift in Sources */,
 				73909B831C42012000F027C7 /* RouterError.swift in Sources */,
 				7349E7651C3DD759004A507B /* Route.swift in Sources */,
+				73FA154D1C42A1E000AA691E /* CallbackCollection.swift in Sources */,
 				73F280061C41F6630043B1BB /* RouterViewController.swift in Sources */,
 				7349E76F1C3DD759004A507B /* ZippedStack.swift in Sources */,
 				7349E76B1C3DD759004A507B /* StackRouter.swift in Sources */,

--- a/Demo/AppCoordinator.swift
+++ b/Demo/AppCoordinator.swift
@@ -13,7 +13,10 @@ func appCoordinator() -> UIViewController {
 
     var router: StackRouter!
     let navigationController = UIStackViewController()
-    let store = AppStore(setPath: { router.setPath(URLPath($0)) })
+    let store = AppStore(setPath: {
+        print("New path: \($0)")
+        router.setPath(URLPath($0))
+    })
 
     router = createRouter([
         Route("welcome", WelcomePresenter(store), [

--- a/Demo/Presenters/LoginPresenter.swift
+++ b/Demo/Presenters/LoginPresenter.swift
@@ -11,8 +11,8 @@ import UIKit
 
 struct LoginPresenter: SegmentViewCreator {
 
-    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController {
-        return FormViewController(ColorViewModel(UIColor.greenColor()), path: path, dismiss: dismiss)
+    func create(path: Path) -> RouterViewController {
+        return FormViewController(ColorViewModel(UIColor.greenColor()), path: path)
     }
 
 }

--- a/Demo/Presenters/RegistrationPresenter.swift
+++ b/Demo/Presenters/RegistrationPresenter.swift
@@ -11,8 +11,8 @@ import UIKit
 
 struct RegistrationPresenter: SegmentViewCreator {
 
-    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController {
-        return FormViewController(ColorViewModel(UIColor.blueColor()), path: path, dismiss: dismiss)
+    func create(path: Path) -> RouterViewController {
+        return FormViewController(ColorViewModel(UIColor.blueColor()), path: path)
     }
 
 }

--- a/Demo/Presenters/WelcomePresenter.swift
+++ b/Demo/Presenters/WelcomePresenter.swift
@@ -17,8 +17,8 @@ struct WelcomePresenter: SegmentViewCreator {
         self.store = store
     }
 
-    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController {
-        return WelcomeViewController(WelcomeViewModel(store: store), path: path, dismiss: dismiss)
+    func create(path: Path) -> RouterViewController {
+        return WelcomeViewController(WelcomeViewModel(store: store), path: path)
     }
 
 }

--- a/Demo/ViewControllers/FormViewController.swift
+++ b/Demo/ViewControllers/FormViewController.swift
@@ -17,12 +17,12 @@ class FormViewController: UIRouterViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(_ viewModel: ProvidesColor, path: Path, dismiss: (Path) -> ()) {
+    init(_ viewModel: ProvidesColor, path: Path) {
         self.viewModel = viewModel
-        super.init(path: path, dismiss: dismiss)
+        super.init(path: path)
     }
 
-    internal required init(path: Path, dismiss: (Path) -> Void) {
+    internal required init(path: Path) {
         fatalError("init(path:dismiss:) has not been implemented")
     }
 

--- a/Demo/ViewControllers/WelcomeViewController.swift
+++ b/Demo/ViewControllers/WelcomeViewController.swift
@@ -19,12 +19,12 @@ class WelcomeViewController: UIRouterViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(_ viewModel: WelcomeViewModel, path: Path, dismiss: (Path) -> ()) {
+    init(_ viewModel: WelcomeViewModel, path: Path) {
         self.viewModel = viewModel
-        super.init(path: path, dismiss: dismiss)
+        super.init(path: path)
     }
 
-    internal required init(path: Path, dismiss: (Path) -> Void) {
+    internal required init(path: Path) {
         fatalError("init(path:dismiss:) has not been implemented")
     }
 

--- a/Sources/Core/CallbackCollection.swift
+++ b/Sources/Core/CallbackCollection.swift
@@ -1,0 +1,58 @@
+//
+//  CallbackCollection.swift
+//  Beeline
+//
+//  Created by Karl Bowden on 11/01/2016.
+//  Copyright © 2016 Featherweight Labs. All rights reserved.
+//
+
+/**
+ A Collection of Callbacks
+
+ A wrapper for callbacks that get called once then cleared.
+
+ It allows for an array of callbacks to be associated with a value type in the same way as a
+ delegate does on a class.
+ */
+public class CallbackCollection<Callback>: SequenceType {
+
+    var contents: [Callback] = []
+
+    public typealias Generator = AnyGenerator<Callback>
+
+    /**
+     Generator<Callback> abstraction
+
+     - returns: Generator<Callback>
+     */
+    public func generate() -> Generator {
+        var index = 0
+        return anyGenerator {
+            if index < self.contents.count {
+                return self.contents[index++]
+            }
+            return nil
+        }
+    }
+
+    /**
+     Add a new callback to the collection to receive the emit event once, or never if this class is
+     destroyed.
+
+     - parameter item: Callback
+     */
+    public func append(item: Callback) {
+        contents.append(item)
+    }
+
+    /**
+     Execute the callback with each item in the callback collection.
+
+     - parameter callback: Callback: (Callback -> Void)
+     */
+    public func emit(callback: Callback -> Void) {
+        contents.forEach(callback)
+        contents = []
+    }
+
+}

--- a/Sources/Core/DismissEmitter.swift
+++ b/Sources/Core/DismissEmitter.swift
@@ -1,0 +1,45 @@
+//
+//  DismissEmitter.swift
+//  Beeline
+//
+//  Created by Karl Bowden on 11/01/2016.
+//  Copyright © 2016 Featherweight Labs. All rights reserved.
+//
+
+public typealias DismissCallback = () -> Void
+public typealias DismissCallbacks = CallbackCollection<DismissCallback>
+
+/**
+ The DismissEmitter protocol allows for callbacks to be added to a collection that will get called
+ once when the emitDismiss function is fired, then disposed of.
+
+ Be weary of causeing strong references when adding callbacks.
+
+ Recommended usage:
+
+ ```swift
+ someitem.onDismiss { [unowned self] in
+     self.doSomething()
+ }
+ ```
+ */
+public protocol DismissEmitter {
+
+    var dismissCallbacks: DismissCallbacks { get set }
+
+    func onDismiss(callback: DismissCallback)
+
+    func emitDismiss()
+}
+
+extension DismissEmitter {
+
+    public func onDismiss(callback: DismissCallback) {
+        dismissCallbacks.append(callback)
+    }
+
+    public func emitDismiss() {
+        dismissCallbacks.emit { $0() }
+    }
+
+}

--- a/Sources/Core/RouterError.swift
+++ b/Sources/Core/RouterError.swift
@@ -1,0 +1,11 @@
+//
+//  RouterError.swift
+//  Beeline
+//
+//  Created by Karl Bowden on 10/01/2016.
+//  Copyright © 2016 Featherweight Labs. All rights reserved.
+//
+
+enum RouterError: ErrorType {
+    case InvalidViewControllerType
+}

--- a/Sources/Core/RouterViewController.swift
+++ b/Sources/Core/RouterViewController.swift
@@ -12,10 +12,8 @@ import UIKit
  Standard RouterViewController Protocol
  This must be implemented by both the iOS and Appkit implementation
  */
-public protocol RouterViewController {
-    var path: Path {get}
-    var dismiss: (Path) -> Void  {get}
-    init(path: Path, dismiss: (Path) -> Void)
+public protocol RouterViewController: DismissEmitter {
+    init(path: Path)
 }
 
 /**
@@ -23,22 +21,26 @@ public protocol RouterViewController {
  */
 public class UIRouterViewController: UIViewController, RouterViewController {
 
-    public var path: Path
-    public var dismiss: (Path) -> Void
+    public var dismissCallbacks = DismissCallbacks()
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public required init(path: Path, dismiss: (Path) -> Void) {
-        self.path = path
-        self.dismiss = dismiss
+    public required init(path: Path) {
         super.init(nibName: nil, bundle: nil)
     }
 
+    /**
+     didMoveToParentViewController is used as the dismiss emitter hook as when using
+     UINavigationController, didMoveToParentViewController is not called until after a user 'swipes'
+     a view away.
+
+     - parameter parent: UIViewController?
+     */
     public override func didMoveToParentViewController(parent: UIViewController?) {
         if parent == nil {
-            dismiss(path)
+            emitDismiss()
         }
         super.didMoveToParentViewController(parent)
     }

--- a/Sources/Core/RouterViewController.swift
+++ b/Sources/Core/RouterViewController.swift
@@ -36,14 +36,11 @@ public class UIRouterViewController: UIViewController, RouterViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    public override func viewWillDisappear(animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        if self.isMovingFromParentViewController() {
-            // Your code...
-            print("I am going back")
+    public override func didMoveToParentViewController(parent: UIViewController?) {
+        if parent == nil {
             dismiss(path)
         }
+        super.didMoveToParentViewController(parent)
     }
 
 }

--- a/Sources/Core/Segment.swift
+++ b/Sources/Core/Segment.swift
@@ -28,8 +28,10 @@ public struct Segment: Equatable {
         self.segmentViewCreator = segmentViewCreator
     }
 
-    func create(dismiss: (Path) -> ()) -> RouterViewController {
-        return segmentViewCreator.create(path, dismiss: dismiss)
+    func create(dismiss: DismissCallback) -> RouterViewController {
+        let routerViewController = segmentViewCreator.create(path)
+        routerViewController.onDismiss(dismiss)
+        return routerViewController
     }
 
 }

--- a/Sources/Core/SegmentViewCreator.swift
+++ b/Sources/Core/SegmentViewCreator.swift
@@ -9,5 +9,5 @@
 import UIKit
 
 public protocol SegmentViewCreator {
-    func create(path: Path, dismiss: (Path) -> ()) -> RouterViewController
+    func create(path: Path) -> RouterViewController
 }

--- a/Sources/Core/StackRouter.swift
+++ b/Sources/Core/StackRouter.swift
@@ -12,12 +12,12 @@ public struct StackRouter {
 
     public var setPath: Path -> Bool
     public var pathStack: Path -> [Segment]?
-    public var dismissViewController: Path -> ()
+    public var dismissViewController: DismissCallback
 
     public init(
         setPath: Path -> Bool,
         pathStack: Path -> [Segment]?,
-        dismissViewController: Path -> ()) {
+        dismissViewController: DismissCallback) {
             self.setPath = setPath
             self.pathStack = pathStack
             self.dismissViewController = dismissViewController
@@ -49,7 +49,7 @@ public func createRouter(routes: [Route], _ viewControler: StackViewController) 
         return nil
     }
 
-    func dissmissViewController(path: Path) {
+    func dissmissViewController() {
         currentStack = previousStack
     }
 

--- a/Sources/Core/StackViewController.swift
+++ b/Sources/Core/StackViewController.swift
@@ -20,7 +20,7 @@ public enum TransitionAction {
  */
 public protocol StackViewController {
 
-    var dismissViewController: Path -> () { get set }
+    var dismissViewController: DismissCallback { get set }
     func setStack(currentStack: [Segment], newStack: [Segment]) -> [Segment]
     func popFromStack(currentStack: [Segment]) -> [Segment]
     func transitionActions(stack: ZippedStack<Segment>) -> [TransitionAction]
@@ -79,7 +79,7 @@ extension StackViewController {
  */
 public class UIStackViewController: UINavigationController, StackViewController {
 
-    public var dismissViewController: Path -> () = { path in }
+    public var dismissViewController: DismissCallback = { _ in }
 
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/Core/StackViewController.swift
+++ b/Sources/Core/StackViewController.swift
@@ -109,8 +109,3 @@ public class UIStackViewController: UINavigationController, StackViewController 
     }
 
 }
-
-
-enum RouterError: ErrorType {
-    case InvalidViewControllerType
-}


### PR DESCRIPTION
didMoveToParentViewController seems to be the best place to emit an the Dismiss event from.
With UINavigationControllers, it is not called until after a user swipes a view away. All other functions fire when before the view is fully swiped away and will cause false firing if the user decides not to swipe the view away in the end.
