### PR TITLE
Provide a minimum deployment target of iOS 8.0 for the iOS framework

### DIFF
--- a/FeatherweightRouter.xcodeproj/project.pbxproj
+++ b/FeatherweightRouter.xcodeproj/project.pbxproj
@@ -788,12 +788,14 @@
 		7349E7481C3DD665004A507B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 			};
 			name = Debug;
 		};
 		7349E7491C3DD665004A507B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 			};
 			name = Release;
 		};
@@ -825,6 +827,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Supporting Files/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.featherweightlabs.FeatherweightRouterDemo;
 				PRODUCT_NAME = FeatherweightRouterDemo;
@@ -836,6 +839,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Supporting Files/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.featherweightlabs.FeatherweightRouterDemo;
 				PRODUCT_NAME = FeatherweightRouterDemo;


### PR DESCRIPTION
This allows the framework to be used against iOS 8 and above targets.
