### PR TITLE
Swift3 support for iOS and macOS frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8
 
 branches:
   only:

--- a/FeatherweightRouter.xcodeproj/project.pbxproj
+++ b/FeatherweightRouter.xcodeproj/project.pbxproj
@@ -436,9 +436,12 @@
 				TargetAttributes = {
 					7349E73E1C3DD665004A507B = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					7349E7771C3DD798004A507B = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = 74D9UBS5CF;
+						LastSwiftMigration = 0800;
 					};
 					7349E7981C3DD963004A507B = {
 						CreatedOnToolsVersion = 7.2;
@@ -789,6 +792,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -796,6 +800,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -803,11 +808,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = 74D9UBS5CF;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.featherweightlabs.FeatherweightRouterTests;
 				PRODUCT_NAME = FeatherweightRouterTests;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -815,10 +822,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = 74D9UBS5CF;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.featherweightlabs.FeatherweightRouterTests;
 				PRODUCT_NAME = FeatherweightRouterTests;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/FeatherweightRouter.xcodeproj/project.pbxproj
+++ b/FeatherweightRouter.xcodeproj/project.pbxproj
@@ -448,9 +448,11 @@
 					};
 					737DF5A61D0D6EB200614CC0 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					737DF5AF1D0D6EB200614CC0 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -859,6 +861,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -866,6 +869,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -881,6 +885,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.featherweightlabs.FeatherweightRouter-macOSTests";
 				PRODUCT_NAME = "FeatherweightRouterTests-macOS";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -896,6 +901,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.featherweightlabs.FeatherweightRouter-macOSTests";
 				PRODUCT_NAME = "FeatherweightRouterTests-macOS";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Sources/Array+pickFirst.swift
+++ b/Sources/Array+pickFirst.swift
@@ -7,7 +7,7 @@ extension Array {
 
      - returns: The first non-nil value returned by the predicate, else nil
      */
-    func pickFirst<T>(predicate: Element -> T?) -> T? {
+    func pickFirst<T>(_ predicate: (Element) -> T?) -> T? {
         for item in self {
             if let result = predicate(item) {
                 return result

--- a/Sources/CachedPresenter.swift
+++ b/Sources/CachedPresenter.swift
@@ -8,7 +8,7 @@
 
  - returns: Presenter<Presentable>
  */
-public func cachedPresenter<ViewController: AnyObject>(createPresentable: () -> ViewController)
+public func cachedPresenter<ViewController: AnyObject>(_ createPresentable: @escaping () -> ViewController)
     -> Presenter<ViewController> {
 
         weak var presentable: ViewController? = nil

--- a/Sources/Presenter.swift
+++ b/Sources/Presenter.swift
@@ -15,11 +15,11 @@ public struct Presenter<ViewController> {
     public var getPresentable: () -> ViewController
 
     /// Sets the child value to the passed in presenter
-    public var setChild: ViewController -> Void = { _ in
+    public var setChild: (ViewController) -> Void = { _ in
         fatalError("Call to unset setChild") }
 
     /// Sets the children value to passed in presenters
-    public var setChildren: [ViewController] -> Void = { _ in
+    public var setChildren: ([ViewController]) -> Void = { _ in
         fatalError("Call to unset setChildren") }
 
     /// The owned presenter
@@ -30,7 +30,7 @@ public struct Presenter<ViewController> {
 
      - parameter child: child presenter
      */
-    public func set(child: ViewController) {
+    public func set(_ child: ViewController) {
         setChild(child)
     }
 
@@ -39,7 +39,7 @@ public struct Presenter<ViewController> {
 
      - parameter children: presenter children
      */
-    public func set(children: [ViewController]) {
+    public func set(_ children: [ViewController]) {
         setChildren(children)
     }
 
@@ -50,8 +50,8 @@ public struct Presenter<ViewController> {
      - parameter setChild:       Callback action to set the child presenter
      - parameter setChildren:    Callback to set the children presenters
      */
-    public init(getPresentable: Void -> ViewController, setChild: (ViewController -> Void)? = nil,
-                setChildren: ([ViewController] -> Void)? = nil) {
+    public init(getPresentable: @escaping (Void) -> ViewController, setChild: ((ViewController) -> Void)? = nil,
+                setChildren: (([ViewController]) -> Void)? = nil) {
         self.getPresentable = getPresentable
         if let setChild = setChild {
             self.setChild = setChild

--- a/Sources/Router+junction.swift
+++ b/Sources/Router+junction.swift
@@ -13,7 +13,7 @@ extension Router {
 
      - returns: Router<T>, a customised copy of self
      */
-    public func junction(junctions: [Router<ViewController, Path>])
+    public func junction(_ junctions: [Router<ViewController, Path>])
         -> Router<ViewController, Path> {
 
             var router = self

--- a/Sources/Router+route.swift
+++ b/Sources/Router+route.swift
@@ -13,7 +13,7 @@ extension Router {
      - returns: A customised copy of Router<T>
      */
     public func route(predicate
-        pathMatches: (Path -> Bool), children: [Router<ViewController, Path>] = []) ->
+        pathMatches: ((Path) -> Bool), children: [Router<ViewController, Path>] = []) ->
         Router<ViewController, Path> {
 
             var router = self

--- a/Sources/Router+route.swift
+++ b/Sources/Router+route.swift
@@ -13,13 +13,13 @@ extension Router {
      - returns: A customised copy of Router<T>
      */
     public func route(predicate
-        pathMatches: ((Path) -> Bool), children: [Router<ViewController, Path>] = []) ->
+        pathMatches: @escaping ((Path) -> Bool), children: [Router<ViewController, Path>] = []) ->
         Router<ViewController, Path> {
 
             var router = self
 
             router.handlesRoute = { path in
-                return pathMatches(path) || children.contains { $0.handlesRoute(path) } ?? false
+                return pathMatches(path) || children.contains { $0.handlesRoute(path) }
             }
 
             router.getStack = { path in

--- a/Sources/Router+stack.swift
+++ b/Sources/Router+stack.swift
@@ -13,7 +13,7 @@ extension Router {
 
      - returns: A customised copy of Router<T>
      */
-    public func stack(stack: [Router<ViewController, Path>]) -> Router<ViewController, Path> {
+    public func stack(_ stack: [Router<ViewController, Path>]) -> Router<ViewController, Path> {
 
         var router = self
 

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -30,12 +30,12 @@ public struct Router<ViewController, Path> {
     /**
      Determines if this Router handles the passed in String
      */
-    public var handlesRoute: Path -> Bool = { _ in false }
+    public var handlesRoute: (Path) -> Bool = { _ in false }
 
     /**
      Passes actions to the Presenter to update the view to the provided String
      */
-    public var setRoute: Path -> Bool = { _ in false }
+    public var setRoute: (Path) -> Bool = { _ in false }
 
     /**
      Returns an array presenters (T) that match the passed in String. The actual array returned can
@@ -43,7 +43,7 @@ public struct Router<ViewController, Path> {
      array of all immediate ancestors, weather they match or now, whereas a Stack Router traverses
      nested children to find a match and returns the matched ancestor tree.
      */
-    public var getStack: Path -> [ViewController]? = { _ in nil }
+    public var getStack: (Path) -> [ViewController]? = { _ in nil }
 
     /**
      Primary Router initialiser
@@ -57,9 +57,9 @@ public struct Router<ViewController, Path> {
      */
     public init(
         _ presenter: Presenter<ViewController>,
-          handlesRoute: (Path -> Bool)? = nil,
-          setRoute: (Path -> Bool)? = nil,
-          getStack: (Path -> [ViewController]?)? = nil) {
+          handlesRoute: ((Path) -> Bool)? = nil,
+          setRoute: ((Path) -> Bool)? = nil,
+          getStack: ((Path) -> [ViewController]?)? = nil) {
 
         self.presenter = presenter
 

--- a/Tests/PresenterTests.swift
+++ b/Tests/PresenterTests.swift
@@ -4,9 +4,9 @@ import XCTest
 class PresenterTests: XCTestCase {
 
     enum MockViewController {
-        case Parent
-        case Child
-        case Other
+        case parent
+        case child
+        case other
     }
 
     func testGetPresentable() {

--- a/Tests/RouterJunctionTests.swift
+++ b/Tests/RouterJunctionTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class RouterJunctionTests: XCTestCase {
 
     enum Presentable {
-        case None, Router, Junction1, Junction2, NestedChild
+        case none, router, junction1, junction2, nestedChild
     }
 
     typealias TestRouter = Router<Presentable, Presentable>
@@ -12,67 +12,67 @@ class RouterJunctionTests: XCTestCase {
     var router: TestRouter!
     var junction1: TestRouter!
     var junction2: TestRouter!
-    var child = Presentable.None
+    var child = Presentable.none
     var children = [Presentable]()
 
     override func setUp() {
         super.setUp()
-        let nestedChild = TestRouter(Presenter(getPresentable: { .NestedChild }))
-            .route(predicate: { $0 == .NestedChild })
-        junction1 = TestRouter(Presenter(getPresentable: { .Junction1 }))
-            .route(predicate: { $0 == .Junction1 }, children: [nestedChild])
-        junction2 = TestRouter(Presenter(getPresentable: { .Junction2 }))
-            .route(predicate: { $0 == .Junction2 })
+        let nestedChild = TestRouter(Presenter(getPresentable: { .nestedChild }))
+            .route(predicate: { $0 == .nestedChild })
+        junction1 = TestRouter(Presenter(getPresentable: { .junction1 }))
+            .route(predicate: { $0 == .junction1 }, children: [nestedChild])
+        junction2 = TestRouter(Presenter(getPresentable: { .junction2 }))
+            .route(predicate: { $0 == .junction2 })
 
-        child = Presentable.None
+        child = Presentable.none
         children = [Presentable]()
 
         router = TestRouter(Presenter(
-            getPresentable: { .Router },
+            getPresentable: { .router },
             setChild: { self.child = $0 },
             setChildren: { self.children = $0 }))
             .junction([junction1, junction2])
     }
 
     func testOnlyHandlesChildRoutes() {
-        XCTAssert(router.handlesRoute(.Junction1))
-        XCTAssert(router.handlesRoute(.Junction2))
-        XCTAssert(router.handlesRoute(.NestedChild))
-        XCTAssertFalse(router.handlesRoute(.Router))
-        XCTAssertFalse(router.handlesRoute(.None))
+        XCTAssert(router.handlesRoute(.junction1))
+        XCTAssert(router.handlesRoute(.junction2))
+        XCTAssert(router.handlesRoute(.nestedChild))
+        XCTAssertFalse(router.handlesRoute(.router))
+        XCTAssertFalse(router.handlesRoute(.none))
     }
 
     func testHandlesRouteDoesntCallPresenters() {
-        XCTAssert(router.handlesRoute(.NestedChild))
+        XCTAssert(router.handlesRoute(.nestedChild))
 
-        XCTAssert(router.presentable == .Router)
-        XCTAssert(child == .None)
+        XCTAssert(router.presentable == .router)
+        XCTAssert(child == .none)
         XCTAssert(children == [])
     }
 
     func testSetRoute() {
-        for path: Presentable in [.Junction1, .Junction2] {
+        for path: Presentable in [.junction1, .junction2] {
             XCTAssert(router.setRoute(path))
             XCTAssert(child == path)
-            XCTAssert(children == [.Junction1, .Junction2])
+            XCTAssert(children == [.junction1, .junction2])
         }
     }
 
     func testSetNestedRoute() {
-        XCTAssert(router.setRoute(.NestedChild))
-        XCTAssert(child == .Junction1)
-        XCTAssert(children == [.Junction1, .Junction2])
+        XCTAssert(router.setRoute(.nestedChild))
+        XCTAssert(child == .junction1)
+        XCTAssert(children == [.junction1, .junction2])
     }
 
     func testSetRouteWithUnhandledRoutes() {
-        XCTAssertFalse(router.setRoute(.Router))
-        XCTAssertFalse(router.setRoute(.None))
+        XCTAssertFalse(router.setRoute(.router))
+        XCTAssertFalse(router.setRoute(.none))
     }
 
     func testSetRouteAlwaysCallsSetChildren() {
-        XCTAssertFalse(router.setRoute(.Router))
-        XCTAssert(child == .None)
-        XCTAssert(children == [.Junction1, .Junction2])
+        XCTAssertFalse(router.setRoute(.router))
+        XCTAssert(child == .none)
+        XCTAssert(children == [.junction1, .junction2])
     }
 
 }

--- a/Tests/RouterRouteTests.swift
+++ b/Tests/RouterRouteTests.swift
@@ -4,69 +4,69 @@ import XCTest
 class RouterRouteTests: XCTestCase {
 
     enum Presentable {
-        case None, Invalid
-        case Presentable, Route, Child1, Child2, NestedChild
+        case none, invalid
+        case presentable, route, child1, child2, nestedChild
     }
 
     typealias TestRouter = Router<Presentable, Presentable>
 
     var route: TestRouter!
-    var child = Presentable.None
+    var child = Presentable.none
     var children = [Presentable]()
 
     override func setUp() {
         super.setUp()
 
-        child = Presentable.None
+        child = Presentable.none
         children = [Presentable]()
 
         route = TestRouter(Presenter(
-            getPresentable: { .Presentable },
+            getPresentable: { .presentable },
             setChild: { self.child = $0 },
             setChildren: { self.children = $0 }))
 
-            .route(predicate: { $0 == .Route }, children: [
+            .route(predicate: { $0 == .route }, children: [
 
-                TestRouter(Presenter(getPresentable: { .Child1 }))
-                    .route(predicate: { $0 == .Child1 }),
+                TestRouter(Presenter(getPresentable: { .child1 }))
+                    .route(predicate: { $0 == .child1 }),
 
-                TestRouter(Presenter(getPresentable: { .Child2 }))
-                    .route(predicate: { $0 == .Child2 }, children: [
+                TestRouter(Presenter(getPresentable: { .child2 }))
+                    .route(predicate: { $0 == .child2 }, children: [
 
-                        TestRouter(Presenter(getPresentable: { .NestedChild }))
-                            .route(predicate: { $0 == .NestedChild }),
+                        TestRouter(Presenter(getPresentable: { .nestedChild }))
+                            .route(predicate: { $0 == .nestedChild }),
                         ]),
                 ])
     }
 
     override func tearDown() {
         route = nil
-        child = .None
+        child = .none
         children = []
         super.tearDown()
     }
 
     func testHandlesRoutes() {
-        XCTAssertFalse(route.handlesRoute(.None))
-        XCTAssertFalse(route.handlesRoute(.Invalid))
-        XCTAssert(route.handlesRoute(.Route))
-        XCTAssert(route.handlesRoute(.Child1))
-        XCTAssert(route.handlesRoute(.Child2))
-        XCTAssert(route.handlesRoute(.NestedChild))
+        XCTAssertFalse(route.handlesRoute(.none))
+        XCTAssertFalse(route.handlesRoute(.invalid))
+        XCTAssert(route.handlesRoute(.route))
+        XCTAssert(route.handlesRoute(.child1))
+        XCTAssert(route.handlesRoute(.child2))
+        XCTAssert(route.handlesRoute(.nestedChild))
     }
 
     func testSetRouteDoesNothing() {
-        XCTAssertFalse(route.setRoute(.Invalid))
-        XCTAssertEqual(child, Presentable.None)
+        XCTAssertFalse(route.setRoute(.invalid))
+        XCTAssertEqual(child, Presentable.none)
         XCTAssertEqual(children, [Presentable]())
     }
 
     func testGetStack() {
         let testValues: [(Presentable, [Presentable])] = [
-            (.Route, [.Presentable]),
-            (.Child1, [.Presentable, .Child1]),
-            (.Child2, [.Presentable, .Child2]),
-            (.NestedChild, [.Presentable, .Child2, .NestedChild]),
+            (.route, [.presentable]),
+            (.child1, [.presentable, .child1]),
+            (.child2, [.presentable, .child2]),
+            (.nestedChild, [.presentable, .child2, .nestedChild]),
         ]
         for (path, stack) in testValues {
             XCTAssertEqual(route.getStack(path)!, stack)

--- a/Tests/RouterStackTests.swift
+++ b/Tests/RouterStackTests.swift
@@ -4,61 +4,61 @@ import XCTest
 class RouterStackTests: XCTestCase {
 
     enum Presentable {
-        case None, Invalid
-        case Presentable, Route, Child1, Child2
+        case none, invalid
+        case presentable, route, child1, child2
     }
 
     typealias TestRouter = Router<Presentable, Presentable>
 
     var router: TestRouter!
-    var child = Presentable.None
+    var child = Presentable.none
     var children = [Presentable]()
 
     override func setUp() {
         super.setUp()
 
-        child = Presentable.None
+        child = Presentable.none
         children = [Presentable]()
 
         router = TestRouter(Presenter(
-            getPresentable: { .Presentable },
+            getPresentable: { .presentable },
             setChild: { self.child = $0 },
             setChildren: { self.children = $0 }))
             .stack([
-                TestRouter(Presenter(getPresentable: { .Child1 }))
-                    .route(predicate: { $0 == .Child1 }),
-                TestRouter(Presenter(getPresentable: { .Child2 }))
-                    .route(predicate: { $0 == .Child2 }),
+                TestRouter(Presenter(getPresentable: { .child1 }))
+                    .route(predicate: { $0 == .child1 }),
+                TestRouter(Presenter(getPresentable: { .child2 }))
+                    .route(predicate: { $0 == .child2 }),
                 ])
     }
 
     override func tearDown() {
         router = nil
-        child = .None
+        child = .none
         children = []
         super.tearDown()
     }
 
     func testHandlesRoute() {
-        XCTAssertFalse(router.handlesRoute(.Presentable))
-        XCTAssert(router.handlesRoute(.Child1))
-        XCTAssert(router.handlesRoute(.Child2))
+        XCTAssertFalse(router.handlesRoute(.presentable))
+        XCTAssert(router.handlesRoute(.child1))
+        XCTAssert(router.handlesRoute(.child2))
     }
 
     func testSetRouteInvalid() {
-        XCTAssert(router.setRoute(.Presentable))
-        XCTAssertEqual(child, Presentable.None)
+        XCTAssert(router.setRoute(.presentable))
+        XCTAssertEqual(child, Presentable.none)
         XCTAssertEqual(children, [Presentable]())
     }
 
     func testSetPresenterChildNeverCalled() {
-        XCTAssert(router.setRoute(.Child1))
-        XCTAssertEqual(child, Presentable.None)
-        XCTAssertEqual(children, [Presentable.Child1])
+        XCTAssert(router.setRoute(.child1))
+        XCTAssertEqual(child, Presentable.none)
+        XCTAssertEqual(children, [Presentable.child1])
     }
 
     func testSetRouteValid() {
-        XCTAssert(router.setRoute(.Child2))
-        XCTAssertEqual(children, [Presentable.Child2])
+        XCTAssert(router.setRoute(.child2))
+        XCTAssertEqual(children, [Presentable.child2])
     }
 }


### PR DESCRIPTION
This change primarily uses the Xcode 8 syntax conversion to get support for swift 3.0.

I'm unsure if we want to be looking at differences in the API or supporting swift 2.3 as well.
